### PR TITLE
Caching

### DIFF
--- a/examples/load_from_plane.rs
+++ b/examples/load_from_plane.rs
@@ -32,7 +32,6 @@ fn setup_grass(mut commands: Commands) {
 }
 fn debug (mut aabb: Query<&mut Aabb, With<Handle<Mesh>>>) {
     for mut aabb in aabb.iter_mut() {
-        println!("{:?}",aabb);
         aabb.half_extents.x =5.;
         aabb.half_extents.z =5.;
     }

--- a/examples/load_from_plane.rs
+++ b/examples/load_from_plane.rs
@@ -1,4 +1,4 @@
-use bevy::{prelude::*, render::primitives::Aabb};
+use bevy::prelude::*;
 use warblersneeds::prelude::*;
 mod helper;
 fn main() {
@@ -7,7 +7,6 @@ fn main() {
         .add_plugin(WarblersPlugin)
         .add_plugin(helper::SimpleCamera)
         .add_startup_system(setup_grass)
-        .add_system(debug)
         .run();
 }
 // In this example 2 planes are used for generating grass blades
@@ -29,10 +28,4 @@ fn setup_grass(mut commands: Commands) {
     let mut grass = plane1.generate_grass(config.clone());
     grass.instances.extend(plane2.generate_grass(config).instances);
     commands.spawn((WarblersBundle { grass, ..default() },));
-}
-fn debug (mut aabb: Query<&mut Aabb, With<Handle<Mesh>>>) {
-    for mut aabb in aabb.iter_mut() {
-        aabb.half_extents.x =5.;
-        aabb.half_extents.z =5.;
-    }
 }

--- a/src/render.rs
+++ b/src/render.rs
@@ -15,7 +15,7 @@ use bevy::{
     render::render_phase::SetItemPipeline,
 };
 
-use crate::{Grass, RegionConfiguration};
+use crate::RegionConfiguration;
 
 use self::cache::GrassCache;
 use self::grass_pipeline::GrassPipeline;
@@ -105,7 +105,7 @@ pub fn queue_grass_buffers(
     mut pipelines: ResMut<SpecializedMeshPipelines<GrassPipeline>>,
     mut pipeline_cache: ResMut<PipelineCache>,
     meshes: Res<RenderAssets<Mesh>>,
-    material_meshes: Query<(Entity, &MeshUniform, &Handle<Mesh>), With<Grass>>,
+    material_meshes: Query<(Entity, &MeshUniform, &Handle<Mesh>)>,
     mut views: Query<(&ExtractedView, &mut RenderPhase<Opaque3d>)>,
 ) {
     let draw_custom = transparent_3d_draw_functions

--- a/src/render.rs
+++ b/src/render.rs
@@ -4,7 +4,7 @@ use bevy::prelude::*;
 use bevy::render::render_asset::RenderAssets;
 use bevy::render::render_phase::{DrawFunctions, RenderPhase};
 use bevy::render::render_resource::{
-    BindGroup, BindGroupDescriptor, BindGroupEntry, BindingResource, Buffer, BufferBinding,
+    BindGroupDescriptor, BindGroupEntry, BindingResource, BufferBinding,
     BufferInitDescriptor, BufferUsages, PipelineCache, SpecializedMeshPipelines,
 };
 use bevy::render::renderer::RenderDevice;
@@ -17,9 +17,12 @@ use bevy::{
 
 use crate::{Grass, RegionConfiguration};
 
+use self::cache::GrassCache;
 use self::grass_pipeline::GrassPipeline;
 mod draw_mesh;
 pub(crate) mod grass_pipeline;
+pub mod extract;
+pub mod cache;
 
 pub(crate) type GrassDrawCall = (
     // caches pipeline instead of reinit every call
@@ -29,26 +32,18 @@ pub(crate) type GrassDrawCall = (
     draw_mesh::DrawMeshInstanced,
 );
 
-#[derive(Component)]
-pub struct InstanceBuffer {
-    entity_buffer: Buffer,
-    uniform_bindgroup: BindGroup,
-    length: usize,
-}
-
 pub(crate) fn prepare_instance_buffers(
-    mut commands: Commands,
     pipeline: Res<GrassPipeline>,
-    query: Query<(Entity, &Grass)>,
+    mut cache: ResMut<GrassCache>,
     region_config: Res<RegionConfiguration>,
     fallback_img: Res<FallbackImage>,
     render_device: Res<RenderDevice>,
     images: Res<RenderAssets<Image>>,
 ) {
-    for (entity, instance_data) in &query {
+    for instance_data in cache.values_mut() {
         let entity_buffer = render_device.create_buffer_with_data(&BufferInitDescriptor {
             label: Some("instance entity data buffer"),
-            contents: bytemuck::cast_slice(instance_data.instances.as_slice()),
+            contents: bytemuck::cast_slice(instance_data.grass.instances.as_slice()),
             usage: BufferUsages::VERTEX | BufferUsages::COPY_DST,
         });
         let region_color_buffer = render_device.create_buffer_with_data(&BufferInitDescriptor {
@@ -97,11 +92,8 @@ pub(crate) fn prepare_instance_buffers(
         };
 
         let bind_group = render_device.create_bind_group(&bind_group_des);
-        commands.entity(entity).insert(InstanceBuffer {
-            entity_buffer,
-            length: instance_data.instances.len(),
-            uniform_bindgroup: bind_group,
-        });
+        instance_data.grass_buffer = Some(entity_buffer);
+        instance_data.uniform_bindgroup = Some(bind_group);
     }
 }
 

--- a/src/render/cache.rs
+++ b/src/render/cache.rs
@@ -1,0 +1,15 @@
+use bevy::{prelude::*, utils::HashMap, render::render_resource::{Buffer, BindGroup}};
+
+use crate::prelude::Grass;
+
+#[derive(Resource, DerefMut, Deref, Debug, Default)]
+pub struct GrassCache {
+    pub data: HashMap<Entity, CachedGrassChunk>,
+}
+#[derive(Debug, Default)]
+pub struct CachedGrassChunk {
+    pub grass: Grass,
+    pub uniform_bindgroup: Option<BindGroup>,
+    pub grass_buffer: Option<Buffer>,
+    pub transform: GlobalTransform,
+}

--- a/src/render/draw_mesh.rs
+++ b/src/render/draw_mesh.rs
@@ -11,34 +11,34 @@ use bevy::{
     },
 };
 
-use super::InstanceBuffer;
+use super::cache::GrassCache;
 pub(crate) struct DrawMeshInstanced;
 
 impl EntityRenderCommand for DrawMeshInstanced {
     type Param = (
         SRes<RenderAssets<Mesh>>,
+        SRes<GrassCache>,
         SQuery<Read<Handle<Mesh>>>,
-        SQuery<Read<InstanceBuffer>>,
     );
 
     #[inline]
     fn render<'w>(
         _view: Entity,
         item: Entity,
-        (meshes, mesh_query, instance_buffer_query): SystemParamItem<'w, '_, Self::Param>,
+        (meshes, cache, mesh_query): SystemParamItem<'w, '_, Self::Param>,
         pass: &mut TrackedRenderPass<'w>,
     ) -> RenderCommandResult {
         let mesh_handle = mesh_query.get(item).unwrap();
-        let instance_buffer = instance_buffer_query.get_inner(item).unwrap();
-
         let gpu_mesh = match meshes.into_inner().get(mesh_handle) {
             Some(gpu_mesh) => gpu_mesh,
             None => return RenderCommandResult::Failure,
         };
         // set uniforms
-        pass.set_bind_group(2, &instance_buffer.uniform_bindgroup, &[]);
+        let chunk = &cache.into_inner()[&item];
+        pass.set_bind_group(2, chunk.uniform_bindgroup.as_ref().unwrap(), &[]);
         pass.set_vertex_buffer(0, gpu_mesh.vertex_buffer.slice(..));
-        pass.set_vertex_buffer(1, instance_buffer.entity_buffer.slice(..));
+        pass.set_vertex_buffer(1, chunk.grass_buffer.as_ref().unwrap().slice(..));
+        let grass_blade_count = chunk.grass.instances.len() as u32;
         match &gpu_mesh.buffer_info {
             GpuBufferInfo::Indexed {
                 buffer,
@@ -46,10 +46,10 @@ impl EntityRenderCommand for DrawMeshInstanced {
                 count,
             } => {
                 pass.set_index_buffer(buffer.slice(..), 0, *index_format);
-                pass.draw_indexed(0..*count, 0, 0..instance_buffer.length as u32);
+                pass.draw_indexed(0..*count, 0, 0..grass_blade_count);
             }
             GpuBufferInfo::NonIndexed { vertex_count } => {
-                pass.draw(0..*vertex_count, 0..instance_buffer.length as u32);
+                pass.draw(0..*vertex_count, 0..grass_blade_count);
             }
         }
         RenderCommandResult::Success

--- a/src/render/extract.rs
+++ b/src/render/extract.rs
@@ -1,0 +1,19 @@
+use bevy::{prelude::*, render::Extract};
+
+use crate::prelude::Grass;
+
+use super::cache::GrassCache;
+
+pub(crate) fn extract_grass(
+    grasses: Extract<Query<(Entity, &Grass, &GlobalTransform, &ComputedVisibility), Or<(Added<Grass>,Changed<Grass>)>>>,
+    mut cache: ResMut<GrassCache>
+) {
+    for (entity, grass,global_transform,  comp_visibility) in grasses.iter() {
+        if !comp_visibility.is_visible() {
+            continue
+        }
+        let cache_value = cache.entry(entity).or_default();
+        cache_value.transform = global_transform.clone();
+        cache_value.grass = grass.clone();
+    }
+}

--- a/src/warblers_plugin.rs
+++ b/src/warblers_plugin.rs
@@ -15,7 +15,7 @@ use bevy::{
 
 use crate::{
     file_loader::{GrassFields, GrassFieldsAssetLoader},
-    render::{self, grass_pipeline::GrassPipeline},
+    render::{self, grass_pipeline::GrassPipeline, cache::GrassCache},
     Grass, RegionConfiguration, prelude::add_aabb_box_to_grass,
 };
 
@@ -46,16 +46,17 @@ impl Plugin for WarblersPlugin {
             .add_asset::<GrassFields>()
             .init_asset_loader::<GrassFieldsAssetLoader>();
         // Add extraction
-        app.add_plugin(ExtractComponentPlugin::<Grass>::extract_visible())
+        app
+            .add_plugin(ExtractComponentPlugin::<Grass>::default())
             .add_plugin(ExtractResourcePlugin::<RegionConfiguration>::default());
         // Init render app
         app.sub_app_mut(RenderApp)
             .add_render_command::<Opaque3d, render::GrassDrawCall>()
-            // .add_render_command::<Transparent3d, render::GrassDrawCall>()
-
             .init_resource::<FallbackImage>()
             .init_resource::<GrassPipeline>()
+            .init_resource::<GrassCache>()
             .init_resource::<SpecializedMeshPipelines<GrassPipeline>>()
+            .add_system_to_stage(RenderStage::Extract, render::extract::extract_grass)
             .add_system_to_stage(RenderStage::Prepare, render::prepare_instance_buffers)
             .add_system_to_stage(RenderStage::Queue, render::queue_grass_buffers);
     }

--- a/src/warblers_plugin.rs
+++ b/src/warblers_plugin.rs
@@ -3,7 +3,6 @@ use bevy::{
     prelude::*,
     reflect::TypeUuid,
     render::{
-        extract_component::ExtractComponentPlugin,
         extract_resource::ExtractResourcePlugin,
         mesh::Indices,
         render_phase::AddRenderCommand,
@@ -15,8 +14,7 @@ use bevy::{
 
 use crate::{
     file_loader::{GrassFields, GrassFieldsAssetLoader},
-    render::{self, grass_pipeline::GrassPipeline, cache::GrassCache},
-    Grass, RegionConfiguration, prelude::add_aabb_box_to_grass,
+    render::{self, grass_pipeline::GrassPipeline, cache::GrassCache}, RegionConfiguration, prelude::add_aabb_box_to_grass,
 };
 
 pub(crate) const GRASS_SHADER_HANDLE: HandleUntyped =
@@ -47,7 +45,6 @@ impl Plugin for WarblersPlugin {
             .init_asset_loader::<GrassFieldsAssetLoader>();
         // Add extraction
         app
-            .add_plugin(ExtractComponentPlugin::<Grass>::default())
             .add_plugin(ExtractResourcePlugin::<RegionConfiguration>::default());
         // Init render app
         app.sub_app_mut(RenderApp)


### PR DESCRIPTION
A cacher in the renderworld was implemented to reduce workload of transfering to the renderworld greatly!

This seem to imply a boost of around 100 fps at the stress test alone.
The current approach however is not refined, if an entity is deleted, the cacher doesn't free the memory for the corresponding grass