### PR TITLE
Improve performance

### DIFF
--- a/src/render/cache.rs
+++ b/src/render/cache.rs
@@ -1,7 +1,7 @@
 use bevy::{
     prelude::*,
     render::render_resource::{BindGroup, Buffer},
-    utils::HashMap,
+    utils::{HashMap, HashSet},
 };
 
 use crate::prelude::Grass;
@@ -20,5 +20,5 @@ pub struct CachedGrassChunk {
 }
 #[derive(Resource, DerefMut, Deref, Debug, Default)]
 pub struct EntityCache {
-    pub entities: Vec<Entity>,
+    pub entities: HashSet<Entity>,
 }

--- a/src/render/extract.rs
+++ b/src/render/extract.rs
@@ -22,8 +22,6 @@ pub(crate) fn extract_grass(
         let cache_value = grass_cache.entry(entity).or_default();
         cache_value.transform = *global_transform;
         cache_value.grass = grass.clone();
-        if !entity_cache.contains(&entity) {
-            entity_cache.push(entity);
-        }
+        entity_cache.insert(entity);
     }
 }

--- a/src/render/queue.rs
+++ b/src/render/queue.rs
@@ -34,7 +34,7 @@ pub fn queue_grass_buffers(
         let rangefinder = view.rangefinder3d();
         for (entity, mesh_uniform, mesh_handle) in material_meshes
             .iter()
-            .filter(|(e, _, _)| cacher.contains(e))
+            .filter(|(e, _, _)| cacher.contains_key(e))
         {
             if let Some(mesh) = meshes.get(mesh_handle) {
                 let key =

--- a/src/render/queue.rs
+++ b/src/render/queue.rs
@@ -34,7 +34,7 @@ pub fn queue_grass_buffers(
         let rangefinder = view.rangefinder3d();
         for (entity, mesh_uniform, mesh_handle) in material_meshes
             .iter()
-            .filter(|(e, _, _)| cacher.contains_key(e))
+            .filter(|(e, _, _)| cacher.contains(e))
         {
             if let Some(mesh) = meshes.get(mesh_handle) {
                 let key =


### PR DESCRIPTION
This way, we don't iterate over every entity in the cache for every entity we add, which is O(n^2), but directly access them in O(1).

Disclaimer: I quickly edited this through the browser, so idk if it actually compiles.