### PR TITLE
Visibility bug for grass not visible at start (Issue16)

### DIFF
--- a/examples/load_many_chunks.rs
+++ b/examples/load_many_chunks.rs
@@ -22,7 +22,7 @@ fn setup_grass_chunks(mut commands: Commands) {
             height: ((x.sin() + z.sin()).cos() + 5.) / 10.,
         })
         .collect();
-    
+
     for chunk in 0..100 {
         let offset = Vec3::new((chunk / 10) as f32 * 6., 0., (chunk % 10) as f32 * 6.);
         commands.spawn(WarblersBundle {

--- a/src/render/extract.rs
+++ b/src/render/extract.rs
@@ -1,25 +1,34 @@
-use bevy::{prelude::*, render::Extract};
-
-use crate::prelude::Grass;
-
 use super::cache::{EntityCache, GrassCache};
+use crate::prelude::Grass;
+use bevy::{prelude::*, render::Extract, utils::HashSet};
 
+/// Extracts the grass data into the render world.
+///
+/// The extraction only happens on change or creation of the entity,
+/// so it normally doesn't come at a high performance cost.
+///
+/// Note:
+/// 1) Currently, the grass data extracted in the render world doesn't get freed when the grass entity is deleted.
+/// 2) If you are changing your grass data constantly you might run into performance problems rather quickly
 #[allow(clippy::type_complexity)]
 pub(crate) fn extract_grass(
-    grasses: Extract<
-        Query<(Entity, &Grass, &GlobalTransform, &ComputedVisibility), Changed<Grass>>,
-    >,
+    grasses: Extract<Query<(Entity, &Grass, &GlobalTransform), Changed<Grass>>>,
     mut grass_cache: ResMut<GrassCache>,
-    mut entity_cache: ResMut<EntityCache>,
 ) {
-    for (entity, grass, global_transform, comp_visibility) in grasses.iter() {
-        if !comp_visibility.is_visible() {
-            entity_cache.remove(&entity);
-            continue;
-        }
+    for (entity, grass, global_transform) in grasses.iter() {
         let cache_value = grass_cache.entry(entity).or_default();
         cache_value.transform = *global_transform;
         cache_value.grass = grass.clone();
-        entity_cache.insert(entity);
     }
+}
+/// Extracts all visible grass entities into the render world.
+pub(crate) fn extract_visibility(
+    visibility_queue: Extract<Query<(Entity, &ComputedVisibility), (With<Grass>, With<Transform>)>>,
+    mut entity_cache: ResMut<EntityCache>,
+) {
+    entity_cache.entities = visibility_queue
+        .iter()
+        .filter(|(_e, visibility)| visibility.is_visible())
+        .map(|(e, _visibility)| e)
+        .collect::<HashSet<Entity>>();
 }

--- a/src/render/extract.rs
+++ b/src/render/extract.rs
@@ -28,7 +28,6 @@ pub(crate) fn extract_visibility(
 ) {
     entity_cache.entities = visibility_queue
         .iter()
-        .filter(|(_e, visibility)| visibility.is_visible())
-        .map(|(e, _visibility)| e)
+        .filter_map(|(e, visibility)| visibility.is_visible().then(|| e))
         .collect();
 }

--- a/src/render/extract.rs
+++ b/src/render/extract.rs
@@ -30,5 +30,5 @@ pub(crate) fn extract_visibility(
         .iter()
         .filter(|(_e, visibility)| visibility.is_visible())
         .map(|(e, _visibility)| e)
-        .collect::<HashSet<Entity>>();
+        .collect();
 }

--- a/src/warblers_plugin.rs
+++ b/src/warblers_plugin.rs
@@ -67,6 +67,7 @@ impl Plugin for WarblersPlugin {
             .init_resource::<EntityCache>()
             .init_resource::<SpecializedMeshPipelines<GrassPipeline>>()
             .add_system_to_stage(RenderStage::Extract, render::extract::extract_grass)
+            .add_system_to_stage(RenderStage::Extract, render::extract::extract_visibility)
             .add_system_to_stage(
                 RenderStage::Prepare,
                 render::prepare::prepare_uniform_buffers,


### PR DESCRIPTION
The extraction is now split into 2 parts.
The `entity_cache` is now extracted from main world every frame. 

Since an Entity is just a light id it doesn't influence performance much