### PR TITLE
Register grass in type registry

### DIFF
--- a/src/grass.rs
+++ b/src/grass.rs
@@ -5,7 +5,7 @@ use bevy::{
 use bytemuck::{Pod, Zeroable};
 
 /// Representation of a single grassblade
-#[derive(Copy, Clone, Debug, Pod, Zeroable, ShaderType)]
+#[derive(Copy, Clone, Debug, Pod, Zeroable, ShaderType, Default, Reflect, FromReflect)]
 #[repr(C)]
 pub struct GrassBlade {
     /// The position of the [GrassBlade].
@@ -19,7 +19,7 @@ pub struct GrassBlade {
 }
 
 /// A collection of grassblades to be extracted later into the render world
-#[derive(Clone, Debug, Component, Default)]
+#[derive(Clone, Debug, Component, Default, Reflect)]
 pub struct Grass {
     pub instances: Vec<GrassBlade>,
 }

--- a/src/warblers_plugin.rs
+++ b/src/warblers_plugin.rs
@@ -15,7 +15,7 @@ use bevy::{
 
 use crate::{
     file_loader::{GrassFields, GrassFieldsAssetLoader},
-    prelude::add_aabb_box_to_grass,
+    prelude::{add_aabb_box_to_grass, Grass},
     render::{
         self,
         cache::{EntityCache, GrassCache},
@@ -23,6 +23,7 @@ use crate::{
     },
     RegionConfiguration,
 };
+
 /// A raw handle which points to the shader used to render the grass.
 pub(crate) const GRASS_SHADER_HANDLE: HandleUntyped =
     HandleUntyped::weak_from_u64(Shader::TYPE_UUID, 2263343952151597127);
@@ -54,6 +55,7 @@ impl Plugin for WarblersPlugin {
         // Init resources
         app.init_resource::<RegionConfiguration>()
             .register_type::<RegionConfiguration>()
+            .register_type::<Grass>()
             .add_asset::<GrassFields>()
             .init_asset_loader::<GrassFieldsAssetLoader>();
         // Add extraction


### PR DESCRIPTION
Allows grass blades to be viewed / edited in `bevy_editor_pls`:
<img width="1118" alt="image" src="https://user-images.githubusercontent.com/9047632/221194440-f3700067-834c-42f7-a558-0cbc4b714963.png">
