### PR TITLE
Fix grass never spawning if cache started out empty

### DIFF
--- a/src/render/prepare.rs
+++ b/src/render/prepare.rs
@@ -41,7 +41,7 @@ pub(crate) fn prepare_uniform_buffers(
         .get(&region_config.wind_noise_texture)
         .unwrap_or(&fallback_img)
         .texture_view;
-    if !region_config.is_changed() && Some(texture.id()) == *last_texture_id {
+    if (!region_config.is_changed() && Some(texture.id()) == *last_texture_id) || cache.is_empty() {
         return;
     }
     *last_texture_id = Some(texture.id());


### PR DESCRIPTION
Discovered this one while lazily loading grass from a tag I put on a GLTF.