### PR TITLE
Fix uniform_bindgroup being None when reloading grass

### DIFF
--- a/src/render/extract.rs
+++ b/src/render/extract.rs
@@ -1,6 +1,6 @@
 use super::cache::{EntityCache, GrassCache};
 use crate::prelude::Grass;
-use bevy::{prelude::*, render::Extract, utils::HashSet};
+use bevy::{prelude::*, render::Extract};
 
 /// Extracts the grass data into the render world.
 ///

--- a/src/render/prepare.rs
+++ b/src/render/prepare.rs
@@ -41,7 +41,8 @@ pub(crate) fn prepare_uniform_buffers(
         .get(&region_config.wind_noise_texture)
         .unwrap_or(&fallback_img)
         .texture_view;
-    if (!region_config.is_changed() && Some(texture.id()) == *last_texture_id) || cache.is_empty() {
+    if !region_config.is_changed() && Some(texture.id()) == *last_texture_id && !cache.is_changed()
+    {
         return;
     }
     *last_texture_id = Some(texture.id());


### PR DESCRIPTION
Twin to #28, I suppose.
The same line crashed when I reloaded the level in Foxtrot.